### PR TITLE
Standardise path helpers

### DIFF
--- a/app/controllers/saved_occupations_controller.rb
+++ b/app/controllers/saved_occupations_controller.rb
@@ -4,7 +4,7 @@ class SavedOccupationsController < ApplicationController
   def create
     # rubocop:disable Lint/HandleExceptions
     @query = params[:query]
-    @occupation = Occupation.find(params[:occupation_id])
+    @occupation = Occupation.find_by(soc_code: params[:soc_code])
 
     begin
       current_scrapbook.occupations << @occupation

--- a/app/controllers/saved_occupations_controller.rb
+++ b/app/controllers/saved_occupations_controller.rb
@@ -2,19 +2,22 @@ class SavedOccupationsController < ApplicationController
   before_action :ensure_current_scrapbook
 
   def create
-    # rubocop:disable Lint/HandleExceptions
     @query = params[:query]
     @occupation = Occupation.find_by(soc_code: params[:soc_code])
-
-    begin
-      current_scrapbook.occupations << @occupation
-    rescue ActiveRecord::RecordNotUnique
-      # ignore duplicate entries
-    end
+    ensure_occupation_saved_to_current_scrapbook(@occupation)
   end
 
   def destroy
     @occupation = Occupation.find_by(soc_code: params[:soc_code])
     current_scrapbook.occupations.delete(@occupation)
+  end
+
+  private
+
+  def ensure_occupation_saved_to_current_scrapbook(occupation)
+    # rubocop:disable Lint/HandleExceptions
+    current_scrapbook.occupations << occupation
+  rescue ActiveRecord::RecordNotUnique
+    # ignore duplicate entries
   end
 end

--- a/app/views/occupations/show.html.erb
+++ b/app/views/occupations/show.html.erb
@@ -1,18 +1,18 @@
 <% content_for :breadcrumbs do %>
   <ol>
-    <li><a href="<%= new_scrapbook_search_path %>">Search</a></li>
-    <li><a href="<%= scrapbook_search_path(query: @query) %>">Results</a></li>
+    <li><a href="<%= new_scrapbook_search_path(current_scrapbook) %>">Search</a></li>
+    <li><a href="<%= scrapbook_search_path(current_scrapbook, query: @query) %>">Results</a></li>
     <li><%= @occupation.title %></li>
   </ol>
 <% end %>
 
 <%= render "occupations/details", occupation: @occupation %>
 
-<%= form_tag(scrapbook_saved_occupations_path, remote: true, method: "POST",
+<%= form_tag(scrapbook_saved_occupations_path(current_scrapbook), remote: true, method: "POST",
              id: "save-occupation-form", class: "save-occupation-form") do |f| %>
   <input type="hidden" name="occupation_id" value="<%= @occupation.id %>">
   <input type="hidden" name="query" value="<%= @query %>">
   <input type="submit" id="save-occupation"  class="button" value="Save">
 <% end %>
 
-<p><a href="<%= scrapbook_search_path(query: @query) %>" id="back-to-search-results" class="link-back">Search results</a></p>
+<p><a href="<%= scrapbook_search_path(current_scrapbook, query: @query) %>" id="back-to-search-results" class="link-back">Search results</a></p>

--- a/app/views/occupations/show.html.erb
+++ b/app/views/occupations/show.html.erb
@@ -10,7 +10,7 @@
 
 <%= form_tag(scrapbook_saved_occupations_path(current_scrapbook), remote: true, method: "POST",
              id: "save-occupation-form", class: "save-occupation-form") do |f| %>
-  <input type="hidden" name="occupation_id" value="<%= @occupation.id %>">
+  <input type="hidden" name="soc_code" value="<%= @occupation.soc_code %>">
   <input type="hidden" name="query" value="<%= @query %>">
   <input type="submit" id="save-occupation"  class="button" value="Save">
 <% end %>

--- a/app/views/saved_occupations/create.html.erb
+++ b/app/views/saved_occupations/create.html.erb
@@ -2,7 +2,7 @@
   <ol>
     <li><a href="<%= new_scrapbook_search_path(current_scrapbook) %>">Search</a></li>
     <li><a href="<%= scrapbook_search_path(current_scrapbook, query: @query) %>">Results</a></li>
-    <li><a href="<%= scrapbook_occupation_path(current_scrapbook, soc_code: @occupation.soc_code, query: @query) %>"><%= @occupation.title %></a></li>
+    <li><a href="<%= scrapbook_occupation_path(current_scrapbook, @occupation, query: @query) %>"><%= @occupation.title %></a></li>
     <li>Saved</li>
   </ol>
 <% end %>
@@ -10,6 +10,6 @@
 <%= render "saved_occupations/confirmation_box", occupation: @occupation %>
 
 <p>
-  <a href="<%= scrapbook_occupation_path(current_scrapbook, soc_code: @occupation.soc_code, query: @query) %>" id="back-to-occupation" class="link-back">Back to "<%= @occupation.title %>"</a><br>
+  <a href="<%= scrapbook_occupation_path(current_scrapbook, @occupation, query: @query) %>" id="back-to-occupation" class="link-back">Back to "<%= @occupation.title %>"</a><br>
   <a href="<%= scrapbook_search_path(current_scrapbook, query: @query) %>" id="back-to-search-results" class="link-back">Back to search results</a>
 </p>

--- a/app/views/saved_occupations/create.html.erb
+++ b/app/views/saved_occupations/create.html.erb
@@ -1,8 +1,8 @@
 <% content_for :breadcrumbs do %>
   <ol>
-    <li><a href="<%= new_scrapbook_search_path %>">Search</a></li>
-    <li><a href="<%= scrapbook_search_path(query: @query) %>">Results</a></li>
-    <li><a href="<%= scrapbook_occupation_path(soc_code: @occupation.soc_code, query: @query) %>"><%= @occupation.title %></a></li>
+    <li><a href="<%= new_scrapbook_search_path(current_scrapbook) %>">Search</a></li>
+    <li><a href="<%= scrapbook_search_path(current_scrapbook, query: @query) %>">Results</a></li>
+    <li><a href="<%= scrapbook_occupation_path(current_scrapbook, soc_code: @occupation.soc_code, query: @query) %>"><%= @occupation.title %></a></li>
     <li>Saved</li>
   </ol>
 <% end %>
@@ -10,6 +10,6 @@
 <%= render "saved_occupations/confirmation_box", occupation: @occupation %>
 
 <p>
-  <a href="<%= scrapbook_occupation_path(soc_code: @occupation.soc_code, query: @query) %>" id="back-to-occupation" class="link-back">Back to "<%= @occupation.title %>"</a><br>
-  <a href="<%= scrapbook_search_path(query: @query) %>" id="back-to-search-results" class="link-back">Back to search results</a>
+  <a href="<%= scrapbook_occupation_path(current_scrapbook, soc_code: @occupation.soc_code, query: @query) %>" id="back-to-occupation" class="link-back">Back to "<%= @occupation.title %>"</a><br>
+  <a href="<%= scrapbook_search_path(current_scrapbook, query: @query) %>" id="back-to-search-results" class="link-back">Back to search results</a>
 </p>

--- a/app/views/searches/_form.html.erb
+++ b/app/views/searches/_form.html.erb
@@ -1,4 +1,4 @@
-<form action="<%= scrapbook_search_path %>" method="GET" id="search-form">
+<form action="<%= scrapbook_search_path(current_scrapbook) %>" method="GET" id="search-form">
   <div class="form-group-related">
     <label class="form-label" for="query">
       <span class="heading-small">Roles, skills and interests</span>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumbs do %>
 <ol>
-  <li><a href="<%= new_scrapbook_search_path %>">Search</a></li>
+  <li><a href="<%= new_scrapbook_search_path(current_scrapbook) %>">Search</a></li>
   <li>Results</li>
 </ol>
 <% end %>
@@ -22,7 +22,7 @@
       <p>Sorry, we couldn't find any results for this job role</p>
     <% else %>
       <% @search_results.each do |search_result| %>
-      <a href="<%= scrapbook_occupation_path(soc_code: search_result.soc, query: @query) %>" class="search-result">
+      <a href="<%= scrapbook_occupation_path(current_scrapbook, soc_code: search_result.soc, query: @query) %>" class="search-result">
         <h4 class="bold-small">
           <%= search_result.title %>
         </h4>

--- a/spec/controllers/saved_occupations_controller_spec.rb
+++ b/spec/controllers/saved_occupations_controller_spec.rb
@@ -4,19 +4,19 @@ describe SavedOccupationsController do
   let(:scrapbook) { Scrapbook.create }
 
   describe "#create" do
-    let(:occupation) { Occupation.create }
+    let(:occupation) { Occupation.create(soc_code: 1234) }
 
     it "associates an occupation with a scrapbook" do
-      post :create, scrapbook_id: scrapbook.id, occupation_id: occupation.id
+      post :create, scrapbook_id: scrapbook.id, soc_code: occupation.soc_code
 
       scrapbook.reload
       expect(scrapbook.occupations).to include(occupation)
     end
 
     it "is idempotent" do
-      post :create, scrapbook_id: scrapbook.id, occupation_id: occupation.id
-      post :create, scrapbook_id: scrapbook.id, occupation_id: occupation.id
-      post :create, scrapbook_id: scrapbook.id, occupation_id: occupation.id
+      post :create, scrapbook_id: scrapbook.id, soc_code: occupation.soc_code
+      post :create, scrapbook_id: scrapbook.id, soc_code: occupation.soc_code
+      post :create, scrapbook_id: scrapbook.id, soc_code: occupation.soc_code
 
       scrapbook.reload
       expect(scrapbook.occupations.size).to eq(1)
@@ -25,7 +25,7 @@ describe SavedOccupationsController do
     it "creates a scrapbook on demand" do
       scrapbook_id = Scrapbook.new_id
 
-      post :create, scrapbook_id: scrapbook_id, occupation_id: occupation.id
+      post :create, scrapbook_id: scrapbook_id, soc_code: occupation.soc_code
 
       expect(Scrapbook.find_by(id: scrapbook_id)).not_to be_nil
     end


### PR DESCRIPTION
Standardises the way that we pass identifiers to path helpers.

This change stops us relying on Rails path helpers magically knowing what the current scrapbook id is, and avoids issues caused by it sometimes being represented as `params[:id]` and other times `params[:scrapbook_id]`.

**Less Rails fanciness.**