### PR TITLE
Use different query params for search and back

### DIFF
--- a/app/controllers/occupations_controller.rb
+++ b/app/controllers/occupations_controller.rb
@@ -5,6 +5,6 @@ class OccupationsController < ApplicationController
 
   def show
     @occupation = Occupation.find_or_import_from_lmi(params[:soc_code])
-    @query = params[:query]
+    @from_query = params[:from_query]
   end
 end

--- a/app/controllers/saved_occupations_controller.rb
+++ b/app/controllers/saved_occupations_controller.rb
@@ -2,7 +2,7 @@ class SavedOccupationsController < ApplicationController
   before_action :ensure_current_scrapbook
 
   def create
-    @query = params[:query]
+    @from_query = params[:from_query]
     @occupation = Occupation.find_by(soc_code: params[:soc_code])
     ensure_occupation_saved_to_current_scrapbook(@occupation)
   end

--- a/app/views/occupations/show.html.erb
+++ b/app/views/occupations/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumbs do %>
   <ol>
     <li><a href="<%= new_scrapbook_search_path(current_scrapbook) %>">Search</a></li>
-    <li><a href="<%= scrapbook_search_path(current_scrapbook, query: @query) %>">Results</a></li>
+    <li><a href="<%= scrapbook_search_path(current_scrapbook, query: @from_query) %>">Results</a></li>
     <li><%= @occupation.title %></li>
   </ol>
 <% end %>
@@ -11,8 +11,8 @@
 <%= form_tag(scrapbook_saved_occupations_path(current_scrapbook), remote: true, method: "POST",
              id: "save-occupation-form", class: "save-occupation-form") do |f| %>
   <input type="hidden" name="soc_code" value="<%= @occupation.soc_code %>">
-  <input type="hidden" name="query" value="<%= @query %>">
+  <input type="hidden" name="from_query" value="<%= @from_query %>">
   <input type="submit" id="save-occupation"  class="button" value="Save">
 <% end %>
 
-<p><a href="<%= scrapbook_search_path(current_scrapbook, query: @query) %>" id="back-to-search-results" class="link-back">Search results</a></p>
+<p><a href="<%= scrapbook_search_path(current_scrapbook, query: @from_query) %>" id="back-to-search-results" class="link-back">Search results</a></p>

--- a/app/views/saved_occupations/create.html.erb
+++ b/app/views/saved_occupations/create.html.erb
@@ -1,8 +1,8 @@
 <% content_for :breadcrumbs do %>
   <ol>
     <li><a href="<%= new_scrapbook_search_path(current_scrapbook) %>">Search</a></li>
-    <li><a href="<%= scrapbook_search_path(current_scrapbook, query: @query) %>">Results</a></li>
-    <li><a href="<%= scrapbook_occupation_path(current_scrapbook, @occupation, query: @query) %>"><%= @occupation.title %></a></li>
+    <li><a href="<%= scrapbook_search_path(current_scrapbook, query: @from_query) %>">Results</a></li>
+    <li><a href="<%= scrapbook_occupation_path(current_scrapbook, @occupation, from_query: @from_query) %>"><%= @occupation.title %></a></li>
     <li>Saved</li>
   </ol>
 <% end %>
@@ -10,6 +10,6 @@
 <%= render "saved_occupations/confirmation_box", occupation: @occupation %>
 
 <p>
-  <a href="<%= scrapbook_occupation_path(current_scrapbook, @occupation, query: @query) %>" id="back-to-occupation" class="link-back">Back to "<%= @occupation.title %>"</a><br>
-  <a href="<%= scrapbook_search_path(current_scrapbook, query: @query) %>" id="back-to-search-results" class="link-back">Back to search results</a>
+  <a href="<%= scrapbook_occupation_path(current_scrapbook, @occupation, from_query: @from_query) %>" id="back-to-occupation" class="link-back">Back to "<%= @occupation.title %>"</a><br>
+  <a href="<%= scrapbook_search_path(current_scrapbook, query: @from_query) %>" id="back-to-search-results" class="link-back">Back to search results</a>
 </p>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -22,7 +22,7 @@
       <p>No roles matched your search. Please check the spelling or try a different search.</p>
     <% else %>
       <% @search_results.each do |search_result| %>
-      <a href="<%= scrapbook_occupation_path(current_scrapbook, soc_code: search_result.soc, query: @query) %>" class="search-result">
+      <a href="<%= scrapbook_occupation_path(current_scrapbook, soc_code: search_result.soc, from_query: @query) %>" class="search-result">
         <h4 class="bold-small">
           <%= search_result.title %>
         </h4>

--- a/features/cassettes/Back_to_search_results/Remember_search_query_through_returning_from_saving.yml
+++ b/features/cassettes/Back_to_search_results/Remember_search_query_through_returning_from_saving.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:06 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Transfer-Encoding:
@@ -142,7 +142,7 @@ http_interactions:
         cleans toilets and bathrooms;\n washes down walls and ceilings;\n empties
         ashtrays, waste bins and removes rubbish."}]'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:06 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/soc/code/4135
@@ -164,7 +164,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:06 GMT
+      - Fri, 11 Mar 2016 15:03:08 GMT
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
@@ -191,7 +191,7 @@ http_interactions:
         (library)","Clipper, press (press cutting agency)","Looker-out, book","Reader
         (press cutting agency)","Supervisor, library"]}'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:06 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:08 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/ashe/estimateHours?coarse=true&soc=4135
@@ -213,7 +213,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:06 GMT
+      - Fri, 11 Mar 2016 15:03:08 GMT
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
@@ -224,7 +224,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"soc":41,"series":[{"year":2012,"hours":38},{"year":2013,"hours":38}]}'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:06 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:08 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/ashe/estimatePay?coarse=true&soc=4135
@@ -246,7 +246,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:06 GMT
+      - Fri, 11 Mar 2016 15:03:08 GMT
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
@@ -257,7 +257,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"soc":41,"series":[{"year":2012,"estpay":470},{"year":2013,"estpay":470}]}'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:06 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:08 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/soc/search?q=library
@@ -279,7 +279,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:06 GMT
+      - Fri, 11 Mar 2016 15:03:08 GMT
       Content-Type:
       - application/json;charset=utf-8
       Transfer-Encoding:
@@ -400,5 +400,5 @@ http_interactions:
         cleans toilets and bathrooms;\n washes down walls and ceilings;\n empties
         ashtrays, waste bins and removes rubbish."}]'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:06 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:08 GMT
 recorded_with: VCR 3.0.1

--- a/features/cassettes/Back_to_search_results/Return_to_search_results_after_saving_an_occupation.yml
+++ b/features/cassettes/Back_to_search_results/Return_to_search_results_after_saving_an_occupation.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:05 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Transfer-Encoding:
@@ -142,7 +142,7 @@ http_interactions:
         cleans toilets and bathrooms;\n washes down walls and ceilings;\n empties
         ashtrays, waste bins and removes rubbish."}]'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:05 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/soc/code/4135
@@ -164,7 +164,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:05 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
@@ -191,7 +191,7 @@ http_interactions:
         (library)","Clipper, press (press cutting agency)","Looker-out, book","Reader
         (press cutting agency)","Supervisor, library"]}'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:05 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/ashe/estimateHours?coarse=true&soc=4135
@@ -213,7 +213,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:05 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
@@ -224,7 +224,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"soc":41,"series":[{"year":2012,"hours":38},{"year":2013,"hours":38}]}'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:05 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/ashe/estimatePay?coarse=true&soc=4135
@@ -246,7 +246,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:05 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
@@ -257,7 +257,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"soc":41,"series":[{"year":2012,"estpay":470},{"year":2013,"estpay":470}]}'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:05 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/soc/search?q=library
@@ -279,7 +279,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:05 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Transfer-Encoding:
@@ -400,5 +400,5 @@ http_interactions:
         cleans toilets and bathrooms;\n washes down walls and ceilings;\n empties
         ashtrays, waste bins and removes rubbish."}]'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:05 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 recorded_with: VCR 3.0.1

--- a/features/cassettes/Back_to_search_results/Return_to_search_results_after_viewing_details_for_a_specific_result.yml
+++ b/features/cassettes/Back_to_search_results/Return_to_search_results_after_viewing_details_for_a_specific_result.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:05 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Transfer-Encoding:
@@ -142,7 +142,7 @@ http_interactions:
         cleans toilets and bathrooms;\n washes down walls and ceilings;\n empties
         ashtrays, waste bins and removes rubbish."}]'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:05 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/soc/code/4135
@@ -164,7 +164,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:05 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
@@ -191,7 +191,7 @@ http_interactions:
         (library)","Clipper, press (press cutting agency)","Looker-out, book","Reader
         (press cutting agency)","Supervisor, library"]}'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:05 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/ashe/estimateHours?coarse=true&soc=4135
@@ -213,7 +213,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:05 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
@@ -224,7 +224,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"soc":41,"series":[{"year":2012,"hours":38},{"year":2013,"hours":38}]}'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:05 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/ashe/estimatePay?coarse=true&soc=4135
@@ -246,7 +246,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:05 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
@@ -257,7 +257,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"soc":41,"series":[{"year":2012,"estpay":470},{"year":2013,"estpay":470}]}'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:05 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 - request:
     method: get
     uri: http://api.lmiforall.org.uk/api/v1/soc/search?q=library
@@ -279,7 +279,7 @@ http_interactions:
       Server:
       - nginx/1.2.7
       Date:
-      - Wed, 17 Feb 2016 16:07:05 GMT
+      - Fri, 11 Mar 2016 15:03:07 GMT
       Content-Type:
       - application/json;charset=utf-8
       Transfer-Encoding:
@@ -400,5 +400,5 @@ http_interactions:
         cleans toilets and bathrooms;\n washes down walls and ceilings;\n empties
         ashtrays, waste bins and removes rubbish."}]'
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 16:07:05 GMT
+  recorded_at: Fri, 11 Mar 2016 15:03:07 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
This prevents GA from counting every page that keeps track of the original
search query as a search.