### PR TITLE
Virtual page views for save/remove occupations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ Documentation:
 Rails:
   Enabled: true
 
+Style/BracesAroundHashParameters:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/app/assets/javascripts/_analytics.js
+++ b/app/assets/javascripts/_analytics.js
@@ -1,5 +1,9 @@
 window.analytics = window.analytics || {
-  virtualPageView: function (path) {
-    window.dataLayer.push({"event": "pageView", "virtualPageViewPath": path});
+  virtualPageView: function (path, title) {
+    window.dataLayer.push({
+      "event": "pageView",
+      "virtualPageViewPath": path,
+      "virtualPageViewTitle": title
+    });
   }
 }

--- a/app/assets/javascripts/_analytics.js
+++ b/app/assets/javascripts/_analytics.js
@@ -1,0 +1,5 @@
+window.analytics = window.analytics || {
+  virtualPageView: function (path) {
+    window.dataLayer.push({"event": "pageView", "virtualPageViewPath": path});
+  }
+}

--- a/app/views/saved_occupations/create.js.erb
+++ b/app/views/saved_occupations/create.js.erb
@@ -1,2 +1,3 @@
 $("#save-occupation-form").replaceWith("<%= escape_javascript(render "saved_occupations/confirmation_box", occupation: @occupation) %>");
 $("#current-scrapbook-link-container").html("<%= escape_javascript(render "scrapbooks/link_to_current_scrapbook") %>");
+window.analytics.virtualPageView("<%= request.path %>");

--- a/app/views/saved_occupations/destroy.js.erb
+++ b/app/views/saved_occupations/destroy.js.erb
@@ -2,3 +2,4 @@ $("#occupation-<%= @occupation.soc_code %>").replaceWith("<%= escape_javascript(
 <% if current_scrapbook.occupations.empty? %>
   $("#scrapbook-preamble").replaceWith("<%= escape_javascript(render "scrapbooks/preamble_empty") %>");
 <% end %>
+window.analytics.virtualPageView("<%= request.path %>");

--- a/app/views/shared/_tag_manager.html.erb
+++ b/app/views/shared/_tag_manager.html.erb
@@ -1,11 +1,10 @@
-<% if ENV.include?("GOOGLE_TAG_MANAGER_ID") %>
-
 <script>
   window.dataLayer = window.dataLayer || [
     { "scrapbookId": "<%= current_scrapbook.id %>" }
   ]
 </script>
 
+<% if ENV.include?("GOOGLE_TAG_MANAGER_ID") %>
 <!-- Google Tag Manager -->
   <noscript><iframe src="//www.googletagmanager.com/ns.html?id=<%= ENV["GOOGLE_TAG_MANAGER_ID"]%>"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/features/step_definitions/remove_occupations_steps.rb
+++ b/features/step_definitions/remove_occupations_steps.rb
@@ -3,7 +3,7 @@ Given(/^I am viewing my scrapbook$/) do
 end
 
 When(/^I remove one of my saved occupations$/) do
-  click_on("remove-occupation-#{specific_search_result[:soc]}")
+  click_on("remove-occupation-#{specific_search_result.fetch(:soc)}")
 end
 
 When(/^I remove all of my saved occupations$/) do
@@ -20,6 +20,19 @@ end
 
 Then(/^I should see an in-situ confirmation that the occupation is removed$/) do
   expect(current_path).to eq scrapbook_path(id: scrapbook_id)
+
+  saved_occupation_path = scrapbook_saved_occupation_path(
+    scrapbook_id: scrapbook_id,
+    soc_code: specific_search_result.fetch(:soc)
+  )
+
+  expect(page).to have_analytics_event(
+    {
+      "event" => "pageView",
+      "virtualPageViewPath" => saved_occupation_path,
+    }
+  )
+
   step("I should see a confirmation that the occupation is removed")
 end
 

--- a/features/step_definitions/save_occupations_steps.rb
+++ b/features/step_definitions/save_occupations_steps.rb
@@ -23,5 +23,16 @@ Then(/^I should see an in\-situ confirmation that the occupation is saved$/) do
 
   expect(current_path).to eq view_occupation_details_path
 
+  saved_occupations_path = scrapbook_saved_occupations_path(
+    scrapbook_id: scrapbook_id
+  )
+
+  expect(page).to have_analytics_event(
+    {
+      "event" => "pageView",
+      "virtualPageViewPath" => saved_occupations_path,
+    }
+  )
+
   step("I should see a confirmation that the occupation is saved")
 end

--- a/features/support/matchers/have_analytics_events.rb
+++ b/features/support/matchers/have_analytics_events.rb
@@ -1,0 +1,34 @@
+require "rspec/matchers"
+require "capybara"
+
+RSpec::Matchers.define :have_analytics_event do |expected|
+  def wait_until(timeout_in_seconds = Capybara.default_max_wait_time)
+    Timeout.timeout(timeout_in_seconds) do
+      sleep(0.1) until (value = yield)
+      value
+    end
+  end
+
+  match do |page|
+    # rubocop:disable Lint/HandleExceptions
+    begin
+      wait_until do
+        @analytics_events = Array(page.evaluate_script("window.dataLayer"))
+        @analytics_events.include?(expected)
+      end
+    rescue Timeout::Error
+      # Do nothing, the actual expectation is run below
+    end
+
+    expect(@analytics_events).to include(expected)
+  end
+
+  failure_message do
+    <<-EOT
+      actual analytics events:
+        #{@analytics_events}
+      were expected to include:
+        #{expected}
+    EOT
+  end
+end


### PR DESCRIPTION
Makes sure that we send the same page views to GA with and without Javascript enabled