### PR TITLE
Add custom healthcheck middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "rails", "~> 4.2"
 gem "pg"
 gem "puma"
 
-gem "health_check"
 gem "httparty"
 gem "jbuilder", "~> 2.0"
 gem "mail"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,8 +86,6 @@ GEM
     govuk_template (0.17.0)
       rails (>= 3.1)
     hashdiff (0.3.0)
-    health_check (1.5.1)
-      rails (>= 2.3.0)
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
@@ -252,7 +250,6 @@ DEPENDENCIES
   database_cleaner
   govuk_frontend_toolkit
   govuk_template
-  health_check
   httparty
   jbuilder (~> 2.0)
   jquery-rails

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,9 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path("../config/environment", __FILE__)
+require ::File.expand_path("../lib/middleware/health_check", __FILE__)
 
+use HealthCheck
 map WorkYouCouldDo::Application.config.relative_url_root || "/" do
   run Rails.application
 end

--- a/lib/middleware/health_check.rb
+++ b/lib/middleware/health_check.rb
@@ -1,0 +1,37 @@
+class HealthCheck
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    return @app.call(env) unless env["PATH_INFO"] == "/health_check"
+
+    database_up? ? success_response : failure_response
+  end
+
+  private
+
+  def database_up?
+    ActiveRecord::Base.connection.execute("SELECT 1+1 AS result")
+  rescue ActiveRecord::ActiveRecordError, PG::Error
+    false
+  else
+    true
+  end
+
+  def success_response
+    [
+      200,
+      { "Content-Type" => "application/json" },
+      ['{status: "ok", database: "up"}'],
+    ]
+  end
+
+  def failure_response
+    [
+      500,
+      { "Content-Type" => "application/json" },
+      ['{status: "failure", database: "down"}'],
+    ]
+  end
+end


### PR DESCRIPTION
The gem we were using is implemented as a Rails engine, which cannot be
mounted outside of the application itself. We need the health check to
be mounted independent of the RAIL_RELATIVE_URL_ROOT environment
variable.