### PR TITLE
[WIP] Remove automatic scrapbook ID generation

### DIFF
--- a/app/controllers/entrypoints_controller.rb
+++ b/app/controllers/entrypoints_controller.rb
@@ -1,0 +1,20 @@
+class EntrypointsController < ApplicationController
+  def show
+    if params.include?(:id)
+      entrypoint_path = if current_scrapbook.saved_occupations.any?
+                          new_scrapbook_search_path(current_scrapbook)
+                        else
+                          scrapbook_introduction_path(current_scrapbook)
+                        end
+      redirect_to entrypoint_path
+    end
+  end
+
+  private
+
+  def current_scrapbook_id
+    # required for the Scrapbooking controller concern to be able to find
+    # the current scrapbook
+    params[:id]
+  end
+end

--- a/app/controllers/scrapbooks_controller.rb
+++ b/app/controllers/scrapbooks_controller.rb
@@ -1,14 +1,4 @@
 class ScrapbooksController < ApplicationController
-  def create
-    params[:id] = Scrapbook.new_id unless params.include?(:id)
-    entrypoint_path = if current_scrapbook.saved_occupations.any?
-                        new_scrapbook_search_path(current_scrapbook)
-                      else
-                        scrapbook_introduction_path(current_scrapbook)
-                      end
-    redirect_to entrypoint_path
-  end
-
   def show
   end
 

--- a/app/views/entrypoints/show.html.erb
+++ b/app/views/entrypoints/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_title_prefix, "How to access this tool") %>
 
-<h2 class="heading-xlarge">How to access this tool</h2>
+<h2 class="heading-xlarge">Sign into your account</h2>
 
-<p>Please access this tool through your Universal Credit account.</p>
+<p>You need to sign into your Universal Credit account to use this tool.</p>

--- a/app/views/entrypoints/show.html.erb
+++ b/app/views/entrypoints/show.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title_prefix, "Sign into your account") %>
+<% content_for(:page_title_prefix, "Sign in to your account") %>
 
-<h2 class="heading-xlarge">Sign into your account</h2>
+<h2 class="heading-xlarge">Sign in to your account</h2>
 
-<p>You need to sign into your Universal Credit account to use this tool.</p>
+<p>You need to sign in to your Universal Credit account to use this tool.</p>

--- a/app/views/entrypoints/show.html.erb
+++ b/app/views/entrypoints/show.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:page_title_prefix, "How to access this tool") %>
+
+<h2 class="heading-xlarge">How to access this tool</h2>
+
+<p>Please access this tool through your Universal Credit account.</p>

--- a/app/views/entrypoints/show.html.erb
+++ b/app/views/entrypoints/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title_prefix, "How to access this tool") %>
+<% content_for(:page_title_prefix, "Sign into your account") %>
 
 <h2 class="heading-xlarge">Sign into your account</h2>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: "scrapbooks#create"
+  root to: "entrypoints#show"
   resources :scrapbooks,
             path: "/",
             only: [:show],

--- a/features/entrypoints.feature
+++ b/features/entrypoints.feature
@@ -16,4 +16,4 @@ Scenario: Access an existing scrapbook
 
 Scenario: Access the tool without a scrapbook identifier
   When I access the tool without a scrapbook identifier
-  Then I should see the introduction page, within a new scrapbook
+  Then I should see access instructions, outside of a scrapbook

--- a/features/step_definitions/entrypoints_steps.rb
+++ b/features/step_definitions/entrypoints_steps.rb
@@ -38,5 +38,7 @@ end
 
 Then(/^I should see access instructions, outside of a scrapbook$/) do
   expect(current_path).not_to match(Scrapbook::VALID_ID)
-  pending
+  expect(page).to have_content(
+    "Please access this tool through your Universal Credit account."
+  )
 end

--- a/features/step_definitions/entrypoints_steps.rb
+++ b/features/step_definitions/entrypoints_steps.rb
@@ -35,3 +35,8 @@ Then(/^I should see the introduction page, within my scrapbook$/) do
     scrapbook_introduction_path(scrapbook_id: scrapbook_id)
   )
 end
+
+Then(/^I should see access instructions, outside of a scrapbook$/) do
+  expect(current_path).not_to match(Scrapbook::VALID_ID)
+  pending
+end


### PR DESCRIPTION
Instead of generating a new scrapbook ID, if someone accesses the tool then we display a page teling them to

"Please access this tool through your Universal Credit account."

This functionality is still TBD, this PR is here in case you need it.