### PR TITLE
Add flag to ignore VCR for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ To run [Cucumber] tests only:
 $ bin/cucumber
 ```
 
+To run tests without VCR (hitting real LMI endpoint):
+```
+$ VCR_OFF=true bin/test
+```
+
 ### Database issues during test runs
 
 If you get a `FATAL:  database "work-you-could-do_test" does not exist` error

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -9,3 +9,8 @@ end
 VCR.cucumber_tags do |t|
   t.tag "@vcr", use_scenario_name: true
 end
+
+unless ENV["VCR_OFF"].nil?
+  WebMock.allow_net_connect!
+  VCR.turn_off!(ignore_cassettes: true)
+end

--- a/spec/vcr.rb
+++ b/spec/vcr.rb
@@ -5,3 +5,8 @@ VCR.configure do |c|
   c.hook_into :webmock
   c.configure_rspec_metadata!
 end
+
+unless ENV["VCR_OFF"].nil?
+  WebMock.allow_net_connect!
+  VCR.turn_off!(ignore_cassettes: true)
+end


### PR DESCRIPTION
- run tests against real LMI endpoint