### PR TITLE
Check response code instead of header for hmac integration

### DIFF
--- a/spec/cassettes/LmiClient/_hours_lookup/returns_200.yml
+++ b/spec/cassettes/LmiClient/_hours_lookup/returns_200.yml
@@ -8,31 +8,29 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Signature keyId="U9CMRK1DQSa5iX4N5wXrLQ==",algorithm="hmac-sha1",signature="WjCOb26fRYZzvhtlSh8fwJPLxHg="
+      - Signature keyId="U9CMRK1DQSa5iX4N5wXrLQ==",algorithm="hmac-sha1",signature="dgQKXNghKXBOlaRwcWQYpSaa4G4="
       Date:
-      - Mon, 20 Feb 2017 16:19:50 GMT
+      - Mon, 24 Apr 2017 14:04:35 GMT
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.2.7
+      - nginx/1.10.0 (Ubuntu)
       Date:
-      - Mon, 20 Feb 2017 16:19:51 GMT
+      - Mon, 24 Apr 2017 14:04:36 GMT
       Content-Type:
-      - application/json;charset=utf-8
-      Content-Length:
-      - '46'
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      X-Auth-Type:
-      - HMAC
       Access-Control-Allow-Origin:
       - "*"
     body:
       encoding: UTF-8
       string: '{"soc":41,"series":[{"year":2015,"hours":39}]}'
     http_version: 
-  recorded_at: Mon, 20 Feb 2017 16:19:51 GMT
+  recorded_at: Mon, 24 Apr 2017 14:04:36 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/LmiClient/_pay_lookup/returns_200.yml
+++ b/spec/cassettes/LmiClient/_pay_lookup/returns_200.yml
@@ -8,31 +8,29 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Signature keyId="U9CMRK1DQSa5iX4N5wXrLQ==",algorithm="hmac-sha1",signature="M5cj1IqzxMACQfmYlajqxGF4UyI="
+      - Signature keyId="U9CMRK1DQSa5iX4N5wXrLQ==",algorithm="hmac-sha1",signature="PAgfgOnqioOUjGp3NbBMiwKcO1o="
       Date:
-      - Mon, 20 Feb 2017 16:20:19 GMT
+      - Mon, 24 Apr 2017 14:04:36 GMT
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.2.7
+      - nginx/1.10.0 (Ubuntu)
       Date:
-      - Mon, 20 Feb 2017 16:20:19 GMT
+      - Mon, 24 Apr 2017 14:04:36 GMT
       Content-Type:
-      - application/json;charset=utf-8
-      Content-Length:
-      - '75'
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      X-Auth-Type:
-      - HMAC
       Access-Control-Allow-Origin:
       - "*"
     body:
       encoding: UTF-8
       string: '{"soc":41,"series":[{"year":2013,"estpay":710},{"year":2015,"estpay":490}]}'
     http_version: 
-  recorded_at: Mon, 20 Feb 2017 16:20:19 GMT
+  recorded_at: Mon, 24 Apr 2017 14:04:36 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/LmiClient/_soc_code_lookup/returns_200.yml
+++ b/spec/cassettes/LmiClient/_soc_code_lookup/returns_200.yml
@@ -8,26 +8,24 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Signature keyId="U9CMRK1DQSa5iX4N5wXrLQ==",algorithm="hmac-sha1",signature="bFao/Zmt3jl1UO2g7t6fgjiGAyc="
+      - Signature keyId="U9CMRK1DQSa5iX4N5wXrLQ==",algorithm="hmac-sha1",signature="PAgfgOnqioOUjGp3NbBMiwKcO1o="
       Date:
-      - Mon, 20 Feb 2017 16:20:58 GMT
+      - Mon, 24 Apr 2017 14:04:36 GMT
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.2.7
+      - nginx/1.10.0 (Ubuntu)
       Date:
-      - Mon, 20 Feb 2017 16:20:58 GMT
+      - Mon, 24 Apr 2017 14:04:36 GMT
       Content-Type:
-      - application/json;charset=utf-8
-      Content-Length:
-      - '1349'
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      X-Auth-Type:
-      - HMAC
       Access-Control-Allow-Origin:
       - "*"
     body:
@@ -41,14 +39,14 @@ http_interactions:
         sorts, catalogues and maintains library records;\n locates and retrieves material
         on request for borrowers;\n issues library material and records date of issue/
         due date for return;\n classifies, labels and indexes new books;\n performs
-        simple repairs on old books.","add_titles":["Abstractor (press cuttings)","Agent,
-        cutting, press","Assistant, archives","Assistant, bibliographic","Assistant,
-        chief (library)","Assistant, clerical (library)","Assistant, counter (library)","Assistant,
-        information (educational establishments)","Assistant, information (library)","Assistant,
-        library","Assistant, resource, learning","Assistant, services, bibliographic","Assistant
-        (library)","Attendant, library","Clerk, cuttings, press","Clerk, library","Clerk
-        (library)","Clipper, press (press cutting agency)","Looker-out, book","Reader
-        (press cutting agency)","Supervisor, library"]}'
+        simple repairs on old books.","add_titles":["Assistant (library)","Assistant,
+        library","Assistant, clerical (library)","Assistant, services, bibliographic","Supervisor,
+        library","Looker-out, book","Assistant, chief (library)","Assistant, information
+        (educational establishments)","Abstractor","Clerk, library","Reader (press
+        cutting agency)","Clerk (library)","Assistant, bibliographic","Assistant,
+        counter (library)","Agent, cutting, press","Clerk, cuttings, press","Assistant,
+        resource, learning","Assistant, archives","Attendant, library","Assistant,
+        information (library)","Clipper, press (press cutting agency)"]}'
     http_version: 
-  recorded_at: Mon, 20 Feb 2017 16:20:58 GMT
+  recorded_at: Mon, 24 Apr 2017 14:04:36 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/LmiClient/_soc_search/returns_200.yml
+++ b/spec/cassettes/LmiClient/_soc_search/returns_200.yml
@@ -8,31 +8,29 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Signature keyId="U9CMRK1DQSa5iX4N5wXrLQ==",algorithm="hmac-sha1",signature="WjCOb26fRYZzvhtlSh8fwJPLxHg="
+      - Signature keyId="U9CMRK1DQSa5iX4N5wXrLQ==",algorithm="hmac-sha1",signature="dgQKXNghKXBOlaRwcWQYpSaa4G4="
       Date:
-      - Mon, 20 Feb 2017 16:19:50 GMT
+      - Mon, 24 Apr 2017 14:04:35 GMT
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.2.7
+      - nginx/1.10.0 (Ubuntu)
       Date:
-      - Mon, 20 Feb 2017 16:19:50 GMT
+      - Mon, 24 Apr 2017 14:04:35 GMT
       Content-Type:
-      - application/json;charset=utf-8
-      Content-Length:
-      - '2'
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      X-Auth-Type:
-      - HMAC
       Access-Control-Allow-Origin:
       - "*"
     body:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 20 Feb 2017 16:19:50 GMT
+  recorded_at: Mon, 24 Apr 2017 14:04:35 GMT
 recorded_with: VCR 3.0.3

--- a/spec/lib/lmi_client_spec.rb
+++ b/spec/lib/lmi_client_spec.rb
@@ -8,30 +8,30 @@ describe LmiClient do
   end
 
   describe "#soc_search", :vcr do
-    it "uses hmac for authentication" do
+    it "returns 200" do
       response = @lmi_client.soc_search "check_authentication"
-      expect(response.headers["x-auth-type"]).to eq("HMAC")
+      expect(response.code).to eq(200)
     end
   end
 
   describe "#hours_lookup", :vcr do
-    it "uses hmac for authentication" do
+    it "returns 200" do
       response = @lmi_client.hours_lookup "4135"
-      expect(response.headers["x-auth-type"]).to eq("HMAC")
+      expect(response.code).to eq(200)
     end
   end
 
   describe "#pay_lookup", :vcr do
-    it "uses hmac for authentication" do
+    it "returns 200" do
       response = @lmi_client.pay_lookup "4135"
-      expect(response.headers["x-auth-type"]).to eq("HMAC")
+      expect(response.code).to eq(200)
     end
   end
 
   describe "#soc_code_lookup", :vcr do
-    it "uses hmac for authentication" do
+    it "returns 200" do
       response = @lmi_client.soc_code_lookup "4135"
-      expect(response.headers["x-auth-type"]).to eq("HMAC")
+      expect(response.code).to eq(200)
     end
   end
 end


### PR DESCRIPTION
Lmi for all is not sending `x-auth-type` response header anymore. Until we get more information
we will be checking reponse http code.