### PR TITLE
[POC] Using redis cache for lmi client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem "sass-rails", "~> 5.0"
 gem "therubyracer", platforms: :ruby
 gem "uglifier", ">= 1.3.0"
 
+gem "redis-store"
+gem "redis-rails"
+
 group :development, :test do
   gem "pry-byebug"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,23 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.1)
     rake (10.5.0)
+    redis (3.3.3)
+    redis-actionpack (5.0.1)
+      actionpack (>= 4.0, < 6)
+      redis-rack (>= 1, < 3)
+      redis-store (>= 1.1.0, < 1.4.0)
+    redis-activesupport (5.0.3)
+      activesupport (>= 3, < 6)
+      redis-store (~> 1.3.0)
+    redis-rack (2.0.2)
+      rack (>= 1.5, < 3)
+      redis-store (>= 1.2, < 1.4)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.3.0)
+      redis (>= 2.2)
     ref (2.0.0)
     request_store (1.3.2)
     rspec-core (3.5.4)
@@ -278,6 +295,8 @@ DEPENDENCIES
   rails (~> 4.2)
   rails_12factor
   rake (< 11.0)
+  redis-rails
+  redis-store
   rspec-rails
   rubocop
   sass-rails (~> 5.0)

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -11,7 +11,7 @@ class SearchesController < ApplicationController
 
   def search_for_soc_occupations(query)
     LmiForAll.new(LmiClient.new)
-             .search(query)
+             .search_cache(query)
              .map { |result| OpenStruct.new(result) }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,4 +43,10 @@ Rails.application.configure do
   config.web_console.whitelisted_ips = %w(10.0.0.0/8
                                           172.16.0.0/12
                                           192.168.0.0/16)
+
+
+  # config.cache_store = :memory_store, { size: 64.megabytes }
+  config.cache_store = :redis_store, 'redis://192.168.255.100:6379/1'
+
+  config.action_controller.perform_caching = true
 end

--- a/lib/lmi_for_all.rb
+++ b/lib/lmi_for_all.rb
@@ -3,6 +3,10 @@ class LmiForAll
     @lmi_client = lmi_client
   end
 
+  def search_cache(query)
+    Rails.cache.fetch('LmiForAll.search' + query) { search(query) }
+  end
+
   def search(query)
     @lmi_client
       .soc_search(query)


### PR DESCRIPTION
Background
------------

This app uses [lmi4all api](http://www.lmiforall.org.uk). In order to decrease the load on 3rd party api we can cache responses locally. 

Solution 
------

We've tried [cachebear](https://github.com/vigetlabs/cachebar) and [dry-ice](https://github.com/homeflow/dry_ice) without a success. Solution here is using [Rails.cache](http://guides.rubyonrails.org/caching_with_rails.html) directly

As a cache store we could use application memory or redis. Redis allows sharing cache between application nodes which is a plus. On production we could use hosted redis from [elasticache](https://aws.amazon.com/elasticache/)

Howto run
--------

Start redis as docker
```
$ docker run --name some-redis -p 6379:6379 -d redis
```

**note** You may need to reconfigure redis ip in `development.rb` to point to your local redis. 

Useful resources
-----------

* https://coderwall.com/p/aazriw/use-redis-as-cache-store-for-rails
* https://www.speedshop.co/2015/07/15/the-complete-guide-to-rails-caching.html
* https://devcenter.heroku.com/articles/building-a-rails-3-application-with-memcache