### PR TITLE
Don't display search query on the search result page

### DIFF
--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -18,9 +18,6 @@
   <p>To find work you could do, please enter a role, skill or interest.</p>
 <% else %>
   <section class="search-results">
-    <h3 class="bold-medium job-description-title">
-      <%= pluralize_without_count(@search_results.size, "Role") %> related to <%= @query %>
-    </h3>
     <% if @search_results.empty? %>
       <% content_for(:page_title_prefix, "No results found for: #{@query}") %>
       <p>No roles matched your search. Please check the spelling or try a different search.</p>


### PR DESCRIPTION
Following similar patent as NCS [example](https://nationalcareersservice.direct.gov.uk/job-profiles/search-results?indexCatalogue=job-profiles&searchQuery=Please%20call%20%2B44%20(0)%207777777777&wordsMode=AllWords)
this PR removes query parameter from page rendered html. This should help with content spoofing attack.